### PR TITLE
Korrektur bei EL: Konjunktion statt Negation

### DIFF
--- a/bl_tafelanschriebe.tex
+++ b/bl_tafelanschriebe.tex
@@ -3995,7 +3995,7 @@ Wir gehen wieder per Induktion über die Struktur von $C$ vor.
       Wenn $C=\top$, dann gilt die Aussage trivialerweise, weil $\top^{\Imc_C} = \Delta^{\Imc_C}$.
     \item[Induktionsschritt.]
       Wir müssen wieder zwei Fälle gemäß des äußersten Konstruktors
-      von $C$ unterscheiden $(\lnot,\exists)$:
+      von $C$ unterscheiden $(\sqcap,\exists)$:
       %
       \goodbreak
       \begin{description}
@@ -4152,7 +4152,7 @@ Es gilt also sowohl $e \in C^\Imc$ als auch $(\Imc_C,d_W) \precsim (\Imc,e)$.
         Für $C=\top$ argumentieren wir analog.
       \item[Induktionsschritt.]
         Wir müssen wieder zwei Fälle gemäß des äußersten Konstruktors
-        von $C$ unterscheiden $(\lnot,\exists)$:
+        von $C$ unterscheiden $(\sqcap,\exists)$:
         %
         \goodbreak
         \begin{description}


### PR DESCRIPTION
In EL wurde bei zwei Fallunterscheidungen Negation erwähnt. Gemeint war wohl Konjunktion.